### PR TITLE
테이블명 변경: `user_account` -> `admin_account`

### DIFF
--- a/src/main/java/com/fastcampus/projectboardadmin/domain/AdminAccount.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/domain/AdminAccount.java
@@ -1,17 +1,14 @@
 package com.fastcampus.projectboardadmin.domain;
-
 import com.fastcampus.projectboardadmin.domain.constant.RoleType;
 import com.fastcampus.projectboardadmin.domain.converter.RoleTypesConverter;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
-
 @Getter
 @ToString(callSuper = true)
 @Table(indexes = {
@@ -20,26 +17,22 @@ import java.util.Set;
         @Index(columnList = "createdBy")
 })
 @Entity
-public class UserAccount extends AuditingFields {
+public class AdminAccount extends AuditingFields {
     @Id
     @Column(length = 50)
     private String userId;
-
     @Setter @Column(nullable = false) private String userPassword;
-
     @Convert(converter = RoleTypesConverter.class)
     @Column(nullable = false)
     private Set<RoleType> roleTypes = new LinkedHashSet<>();
-
-
     @Setter @Column(length = 100) private String email;
     @Setter @Column(length = 100) private String nickname;
     @Setter private String memo;
 
 
-    protected UserAccount() {}
+    protected AdminAccount() {}
 
-    private UserAccount(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, String createdBy) {
+    private AdminAccount(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, String createdBy) {
         this.userId = userId;
         this.userPassword = userPassword;
         this.roleTypes = roleTypes;
@@ -50,30 +43,27 @@ public class UserAccount extends AuditingFields {
         this.modifiedBy = createdBy;
     }
 
-    public static UserAccount of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo) {
-        return UserAccount.of(userId, userPassword, roleTypes, email, nickname, memo, null);
+    public static AdminAccount of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo) {
+        return AdminAccount.of(userId, userPassword, roleTypes, email, nickname, memo, null);
     }
 
-    public static UserAccount of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, String createdBy) {
-        return new UserAccount(userId, userPassword, roleTypes, email, nickname, memo, createdBy);
+    public static AdminAccount of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, String createdBy) {
+        return new AdminAccount(userId, userPassword, roleTypes, email, nickname, memo, createdBy);
     }
 
     public void addRoleType(RoleType roleType) {
         this.getRoleTypes().add(roleType);
     }
-
     public void addRoleTypes(Collection<RoleType> roleTypes) {
         this.getRoleTypes().addAll(roleTypes);
     }
-
     public void removeRoleType(RoleType roleType) {
         this.getRoleTypes().remove(roleType);
     }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof UserAccount that)) return false;
+        if (!(o instanceof AdminAccount that)) return false;
         return this.getUserId() != null && this.getUserId().equals(that.getUserId());
     }
 
@@ -81,5 +71,4 @@ public class UserAccount extends AuditingFields {
     public int hashCode() {
         return Objects.hash(this.getUserId());
     }
-
 }

--- a/src/main/java/com/fastcampus/projectboardadmin/dto/AdminAccountDto.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/dto/AdminAccountDto.java
@@ -1,0 +1,56 @@
+package com.fastcampus.projectboardadmin.dto;
+
+import com.fastcampus.projectboardadmin.domain.AdminAccount;
+import com.fastcampus.projectboardadmin.domain.constant.RoleType;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+public record AdminAccountDto(
+        String userId,
+        String userPassword,
+        Set<RoleType> roleTypes,
+        String email,
+        String nickname,
+        String memo,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime modifiedAt,
+        String modifiedBy
+) {
+
+    public static AdminAccountDto of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo) {
+        return AdminAccountDto.of(userId, userPassword, roleTypes, email, nickname, memo, null, null, null, null);
+    }
+
+    public static AdminAccountDto of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new AdminAccountDto(userId, userPassword, roleTypes, email, nickname, memo, createdAt, createdBy, modifiedAt, modifiedBy);
+    }
+
+    public static AdminAccountDto from(AdminAccount entity) {
+        return new AdminAccountDto(
+                entity.getUserId(),
+                entity.getUserPassword(),
+                entity.getRoleTypes(),
+                entity.getEmail(),
+                entity.getNickname(),
+                entity.getMemo(),
+                entity.getCreatedAt(),
+                entity.getCreatedBy(),
+                entity.getModifiedAt(),
+                entity.getModifiedBy()
+        );
+    }
+
+    public AdminAccount toEntity() {
+        return AdminAccount.of(
+                userId,
+                userPassword,
+                roleTypes,
+                email,
+                nickname,
+                memo
+        );
+    }
+
+}

--- a/src/main/java/com/fastcampus/projectboardadmin/dto/UserAccountDto.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/dto/UserAccountDto.java
@@ -1,6 +1,5 @@
 package com.fastcampus.projectboardadmin.dto;
 
-import com.fastcampus.projectboardadmin.domain.UserAccount;
 import com.fastcampus.projectboardadmin.domain.constant.RoleType;
 
 import java.time.LocalDateTime;
@@ -8,7 +7,6 @@ import java.util.Set;
 
 public record UserAccountDto(
         String userId,
-        String userPassword,
         Set<RoleType> roleTypes,
         String email,
         String nickname,
@@ -19,35 +17,12 @@ public record UserAccountDto(
         String modifiedBy
 ) {
 
-    public static UserAccountDto of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo) {
-        return UserAccountDto.of(userId, userPassword, roleTypes, email, nickname, memo, null, null, null, null);
+    public static UserAccountDto of(String userId, Set<RoleType> roleTypes, String email, String nickname, String memo) {
+        return UserAccountDto.of(userId, roleTypes, email, nickname, memo, null, null, null, null);
     }
 
-    public static UserAccountDto of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
-        return new UserAccountDto(userId, userPassword, roleTypes, email, nickname, memo, createdAt, createdBy, modifiedAt, modifiedBy);
+    public static UserAccountDto of(String userId, Set<RoleType> roleTypes, String email, String nickname, String memo, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new UserAccountDto(userId, roleTypes, email, nickname, memo, createdAt, createdBy, modifiedAt, modifiedBy);
     }
-    public static UserAccountDto from(UserAccount entity) {
-        return new UserAccountDto(
-                entity.getUserId(),
-                entity.getUserPassword(),
-                entity.getRoleTypes(),
-                entity.getEmail(),
-                entity.getNickname(),
-                entity.getMemo(),
-                entity.getCreatedAt(),
-                entity.getCreatedBy(),
-                entity.getModifiedAt(),
-                entity.getModifiedBy()
-        );
-    }
-    public UserAccount toEntity() {
-        return UserAccount.of(
-                userId,
-                userPassword,
-                roleTypes,
-                email,
-                nickname,
-                memo
-        );
-    }
+
 }

--- a/src/main/java/com/fastcampus/projectboardadmin/dto/security/BoardAdminPrincipal.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/dto/security/BoardAdminPrincipal.java
@@ -1,13 +1,11 @@
 package com.fastcampus.projectboardadmin.dto.security;
 
 import com.fastcampus.projectboardadmin.domain.constant.RoleType;
-import com.fastcampus.projectboardadmin.dto.UserAccountDto;
-import lombok.Getter;
+import com.fastcampus.projectboardadmin.dto.AdminAccountDto;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.oauth2.core.user.OAuth2User;
-
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
@@ -21,11 +19,9 @@ public record BoardAdminPrincipal(
         String memo,
         Map<String, Object> oAuth2Attributes
 ) implements UserDetails, OAuth2User {
-
     public static BoardAdminPrincipal of(String username, String password, Set<RoleType> roleTypes, String email, String nickname, String memo) {
         return BoardAdminPrincipal.of(username, password, roleTypes, email, nickname, memo, Map.of());
     }
-
     public static BoardAdminPrincipal of(String username, String password, Set<RoleType> roleTypes, String email, String nickname, String memo, Map<String, Object> oAuth2Attributes) {
         return new BoardAdminPrincipal(
                 username,
@@ -41,7 +37,8 @@ public record BoardAdminPrincipal(
                 oAuth2Attributes
         );
     }
-    public static BoardAdminPrincipal from(UserAccountDto dto) {
+
+    public static BoardAdminPrincipal from(AdminAccountDto dto) {
         return BoardAdminPrincipal.of(
                 dto.userId(),
                 dto.userPassword(),
@@ -51,8 +48,9 @@ public record BoardAdminPrincipal(
                 dto.memo()
         );
     }
-    public UserAccountDto toDto() {
-        return UserAccountDto.of(
+
+    public AdminAccountDto toDto() {
+        return AdminAccountDto.of(
                 username,
                 password,
                 authorities.stream()

--- a/src/main/java/com/fastcampus/projectboardadmin/repository/AdminAccountRepository.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/repository/AdminAccountRepository.java
@@ -1,0 +1,7 @@
+package com.fastcampus.projectboardadmin.repository;
+
+import com.fastcampus.projectboardadmin.domain.AdminAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdminAccountRepository extends JpaRepository<AdminAccount, String> {
+}

--- a/src/main/java/com/fastcampus/projectboardadmin/repository/UserAccountRepository.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/repository/UserAccountRepository.java
@@ -1,8 +1,0 @@
-package com.fastcampus.projectboardadmin.repository;
-
-import com.fastcampus.projectboardadmin.domain.UserAccount;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface UserAccountRepository extends JpaRepository<UserAccount, String> {
-
-}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,7 +1,8 @@
-
-insert into user_account (user_id, user_password, role_types, nickname, email, memo, created_at, created_by, modified_at, modified_by) values
-                                                                                                                                           ('uno', '{noop}asdf1234', 'ADMIN', 'Uno', 'uno@mail.com', 'I am Uno.', now(), 'uno', now(), 'uno'),
-                                                                                                                                           ('mark', '{noop}asdf1234', 'MANAGER', 'Mark', 'mark@mail.com', 'I am Mark.', now(), 'uno', now(), 'uno'),
-                                                                                                                                           ('susan', '{noop}asdf1234', 'MANAGER,DEVELOPER', 'Susan', 'Susan@mail.com', 'I am Susan.', now(), 'uno', now(), 'uno'),
-                                                                                                                                           ('jim', '{noop}asdf1234', 'USER', 'Jim', 'jim@mail.com', 'I am Jim.', now(), 'uno', now(), 'uno')
+-- 테스트 계정
+-- TODO: 테스트용이지만 비밀번호가 노출된 데이터 세팅. 개선하는 것이 좋을 지 고민해 보자.
+insert into admin_account (user_id, user_password, role_types, nickname, email, memo, created_at, created_by, modified_at, modified_by) values
+                                                                                                                                            ('uno', '{noop}asdf1234', 'ADMIN', 'Uno', 'uno@mail.com', 'I am Uno.', now(), 'uno', now(), 'uno'),
+                                                                                                                                            ('mark', '{noop}asdf1234', 'MANAGER', 'Mark', 'mark@mail.com', 'I am Mark.', now(), 'uno', now(), 'uno'),
+                                                                                                                                            ('susan', '{noop}asdf1234', 'MANAGER,DEVELOPER', 'Susan', 'Susan@mail.com', 'I am Susan.', now(), 'uno', now(), 'uno'),
+                                                                                                                                            ('jim', '{noop}asdf1234', 'USER', 'Jim', 'jim@mail.com', 'I am Jim.', now(), 'uno', now(), 'uno')
 ;

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementControllerTest.java
@@ -1,5 +1,4 @@
 package com.fastcampus.projectboardadmin.controller;
-
 import com.fastcampus.projectboardadmin.config.SecurityConfig;
 import com.fastcampus.projectboardadmin.domain.constant.RoleType;
 import com.fastcampus.projectboardadmin.dto.ArticleCommentDto;
@@ -13,34 +12,28 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
-
 import static org.mockito.BDDMockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
 @DisplayName("컨트롤러 - 댓글 관리")
 @Import(SecurityConfig.class)
 @WebMvcTest(ArticleCommentManagementController.class)
 class ArticleCommentManagementControllerTest {
     private final MockMvc mvc;
-
     @MockBean private ArticleCommentManagementService articleCommentManagementService;
     public ArticleCommentManagementControllerTest(@Autowired MockMvc mvc) {
         this.mvc = mvc;
     }
-
     @DisplayName("[view][GET] 댓글 관리 페이지 - 정상 호출")
     @Test
     void givenNothing_whenRequestingArticleCommentManagementView_thenReturnsArticleCommentManagementView() throws Exception {
         // Given
         given(articleCommentManagementService.getArticleComments()).willReturn(List.of());
-
         // When & Then
         mvc.perform(get("/management/article-comments"))
                 .andExpect(status().isOk())
@@ -56,7 +49,6 @@ class ArticleCommentManagementControllerTest {
         Long articleCommentId = 1L;
         ArticleCommentDto articleCommentDto = createArticleCommentDto("comment");
         given(articleCommentManagementService.getArticleComment(articleCommentId)).willReturn(articleCommentDto);
-
         // When & Then
         mvc.perform(get("/management/article-comments/" + articleCommentId))
                 .andExpect(status().isOk())
@@ -66,26 +58,22 @@ class ArticleCommentManagementControllerTest {
                 .andExpect(jsonPath("$.userAccount.nickname").value(articleCommentDto.userAccount().nickname()));
         then(articleCommentManagementService).should().getArticleComment(articleCommentId);
     }
-
     @DisplayName("[view][POST] 댓글 삭제 - 정상 호출")
     @Test
     void givenCommentId_whenRequestingDeletion_thenRedirectsToArticleCommentManagementView() throws Exception {
         // Given
         Long articleCommentId = 1L;
         willDoNothing().given(articleCommentManagementService).deleteArticleComment(articleCommentId);
-
         // When & Then
         mvc.perform(
-                post("/management/article-comments/" + articleCommentId)
-                        .with(csrf())
+                        post("/management/article-comments/" + articleCommentId)
+                                .with(csrf())
                 )
                 .andExpect(status().is3xxRedirection())
                 .andExpect(view().name("redirect:/management/article-comments"))
                 .andExpect(redirectedUrl("/management/article-comments"));
         then(articleCommentManagementService).should().deleteArticleComment(articleCommentId);
     }
-
-
     private ArticleCommentDto createArticleCommentDto(String content) {
         return ArticleCommentDto.of(
                 1L,
@@ -99,11 +87,9 @@ class ArticleCommentManagementControllerTest {
                 "Uno"
         );
     }
-
     private UserAccountDto createUserAccountDto() {
         return UserAccountDto.of(
                 "unoTest",
-                "pw",
                 Set.of(RoleType.ADMIN),
                 "uno-test@email.com",
                 "uno-test",

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleManagementControllerTest.java
@@ -20,7 +20,6 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
 @DisplayName("컨트롤러 - 게시글 관리")
 @Import(SecurityConfig.class)
 @WebMvcTest(ArticleManagementController.class)
@@ -60,7 +59,6 @@ class ArticleManagementControllerTest {
                 .andExpect(jsonPath("$.userAccount.nickname").value(articleDto.userAccount().nickname()));
         then(articleManagementService).should().getArticle(articleId);
     }
-
     @DisplayName("[view][POST] 게시글 삭제 - 정상 호출")
     @Test
     void givenArticleId_whenRequestingDeletion_thenRedirectsToArticleManagementView() throws Exception {
@@ -93,7 +91,6 @@ class ArticleManagementControllerTest {
     private UserAccountDto createUserAccountDto() {
         return UserAccountDto.of(
                 "unoTest",
-                "pw",
                 Set.of(RoleType.ADMIN),
                 "uno-test@email.com",
                 "uno-test",

--- a/src/test/java/com/fastcampus/projectboardadmin/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/repository/JpaRepositoryTest.java
@@ -1,6 +1,6 @@
 package com.fastcampus.projectboardadmin.repository;
 
-import com.fastcampus.projectboardadmin.domain.UserAccount;
+import com.fastcampus.projectboardadmin.domain.AdminAccount;
 import com.fastcampus.projectboardadmin.domain.constant.RoleType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -11,22 +11,19 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-
 import static org.assertj.core.api.Assertions.assertThat;
-
 @DisplayName("JPA 연결 테스트")
 @Import(JpaRepositoryTest.TestJpaConfig.class)
 @DataJpaTest
 class JpaRepositoryTest {
 
-    private final UserAccountRepository userAccountRepository;
+    private final AdminAccountRepository adminAccountRepository;
 
-    public JpaRepositoryTest(@Autowired UserAccountRepository userAccountRepository) {
-        this.userAccountRepository = userAccountRepository;
+    public JpaRepositoryTest(@Autowired AdminAccountRepository adminAccountRepository) {
+        this.adminAccountRepository = adminAccountRepository;
     }
 
     @DisplayName("회원 정보 select 테스트")
@@ -35,58 +32,56 @@ class JpaRepositoryTest {
         // Given
 
         // When
-        List<UserAccount> userAccounts = userAccountRepository.findAll();
+        List<AdminAccount> adminAccounts = adminAccountRepository.findAll();
 
         // Then
-        assertThat(userAccounts)
+        assertThat(adminAccounts)
                 .isNotNull()
                 .hasSize(4);
     }
-
     @DisplayName("회원 정보 insert 테스트")
     @Test
     void givenUserAccount_whenInserting_thenWorksFine() {
         // Given
-        long previousCount = userAccountRepository.count();
-        UserAccount userAccount = UserAccount.of("test", "pw", Set.of(RoleType.DEVELOPER), null, null, null);
+        long previousCount = adminAccountRepository.count();
+        AdminAccount adminAccount = AdminAccount.of("test", "pw", Set.of(RoleType.DEVELOPER), null, null, null);
 
         // When
-        userAccountRepository.save(userAccount);
+        adminAccountRepository.save(adminAccount);
 
         // Then
-        assertThat(userAccountRepository.count()).isEqualTo(previousCount + 1);
+        assertThat(adminAccountRepository.count()).isEqualTo(previousCount + 1);
     }
 
     @DisplayName("회원 정보 update 테스트")
     @Test
     void givenUserAccountAndRoleType_whenUpdating_thenWorksFine() {
         // Given
-        UserAccount userAccount = userAccountRepository.getReferenceById("uno");
-        userAccount.addRoleType(RoleType.DEVELOPER);
-        userAccount.addRoleTypes(List.of(RoleType.USER, RoleType.USER));
-        userAccount.removeRoleType(RoleType.ADMIN);
+        AdminAccount adminAccount = adminAccountRepository.getReferenceById("uno");
+        adminAccount.addRoleType(RoleType.DEVELOPER);
+        adminAccount.addRoleTypes(List.of(RoleType.USER, RoleType.USER));
+        adminAccount.removeRoleType(RoleType.ADMIN);
 
         // When
-        UserAccount updatedAccount = userAccountRepository.saveAndFlush(userAccount);
+        AdminAccount updatedAccount = adminAccountRepository.saveAndFlush(adminAccount);
 
         // Then
         assertThat(updatedAccount)
                 .hasFieldOrPropertyWithValue("userId", "uno")
                 .hasFieldOrPropertyWithValue("roleTypes", Set.of(RoleType.DEVELOPER, RoleType.USER));
     }
-
     @DisplayName("회원 정보 delete 테스트")
     @Test
     void givenUserAccount_whenDeleting_thenWorksFine() {
         // Given
-        long previousCount = userAccountRepository.count();
-        UserAccount userAccount = userAccountRepository.getReferenceById("uno");
+        long previousCount = adminAccountRepository.count();
+        AdminAccount adminAccount = adminAccountRepository.getReferenceById("uno");
 
         // When
-        userAccountRepository.delete(userAccount);
+        adminAccountRepository.delete(adminAccount);
 
         // Then
-        assertThat(userAccountRepository.count()).isEqualTo(previousCount - 1);
+        assertThat(adminAccountRepository.count()).isEqualTo(previousCount - 1);
     }
 
 
@@ -98,5 +93,4 @@ class JpaRepositoryTest {
             return () -> Optional.of("uno");
         }
     }
-
 }

--- a/src/test/java/com/fastcampus/projectboardadmin/service/ArticleCommentManagementServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/service/ArticleCommentManagementServiceTest.java
@@ -1,5 +1,4 @@
 package com.fastcampus.projectboardadmin.service;
-
 import com.fastcampus.projectboardadmin.domain.constant.RoleType;
 import com.fastcampus.projectboardadmin.dto.ArticleCommentDto;
 import com.fastcampus.projectboardadmin.dto.UserAccountDto;
@@ -18,73 +17,59 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.client.MockRestServiceServer;
-
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
-
 @ActiveProfiles("test")
 @DisplayName("비즈니스 로직 - 댓글 관리")
 class ArticleCommentManagementServiceTest {
-
     //    @Disabled("실제 API 호출 결과 관찰용이므로 평상시엔 비활성화")
     @DisplayName("실제 API 호출 테스트")
     @SpringBootTest
     @Nested
     class RealApiTest {
-
         private final ArticleCommentManagementService sut;
-
         @Autowired
         public RealApiTest(ArticleCommentManagementService sut) {
             this.sut = sut;
         }
-
         @DisplayName("댓글 API를 호출하면, 댓글을 가져온다.")
         @Test
         void givenNothing_whenCallingCommentApi_thenReturnsCommentList() {
             // Given
-
             // When
             List<ArticleCommentDto> result = sut.getArticleComments();
-
             // Then
             System.out.println(result.stream().findFirst());
             assertThat(result).isNotNull();
         }
     }
-
     @DisplayName("API mocking 테스트")
     @EnableConfigurationProperties(ProjectProperties.class)
     @AutoConfigureWebClient(registerRestTemplate = true)
     @RestClientTest(ArticleCommentManagementService.class)
     @Nested
     class RestTemplateTest {
-
         private final ArticleCommentManagementService sut;
         private final ProjectProperties projectProperties;
         private final MockRestServiceServer server;
         private final ObjectMapper mapper;
-
         @Autowired
         public RestTemplateTest(
                 ArticleCommentManagementService sut,
                 ProjectProperties projectProperties,
                 MockRestServiceServer server,
                 ObjectMapper mapper
-
         ) {
             this.sut = sut;
             this.projectProperties = projectProperties;
             this.server = server;
             this.mapper = mapper;
         }
-
         @DisplayName("댓글 목록 API을 호출하면, 댓글들을 가져온다.")
         @Test
         void givenNothing_whenCallingCommentsApi_thenReturnsCommentList() throws Exception {
@@ -97,11 +82,8 @@ class ArticleCommentManagementServiceTest {
                             mapper.writeValueAsString(expectedResponse),
                             MediaType.APPLICATION_JSON
                     ));
-
-
             // When
             List<ArticleCommentDto> result = sut.getArticleComments();
-
             // Then
             assertThat(result).first()
                     .hasFieldOrPropertyWithValue("id", expectedComment.id())
@@ -109,7 +91,6 @@ class ArticleCommentManagementServiceTest {
                     .hasFieldOrPropertyWithValue("userAccount.nickname", expectedComment.userAccount().nickname());
             server.verify();
         }
-
         @DisplayName("댓글 ID와 함께 댓글 API을 호출하면, 댓글을 가져온다.")
         @Test
         void givenCommentId_whenCallingCommentApi_thenReturnsComment() throws Exception {
@@ -122,11 +103,8 @@ class ArticleCommentManagementServiceTest {
                             mapper.writeValueAsString(expectedComment),
                             MediaType.APPLICATION_JSON
                     ));
-
-
             // When
             ArticleCommentDto result = sut.getArticleComment(articleCommentId);
-
             // Then
             assertThat(result)
                     .hasFieldOrPropertyWithValue("id", expectedComment.id())
@@ -134,7 +112,6 @@ class ArticleCommentManagementServiceTest {
                     .hasFieldOrPropertyWithValue("userAccount.nickname", expectedComment.userAccount().nickname());
             server.verify();
         }
-
         @DisplayName("댓글 ID와 함께 댓글 삭제 API을 호출하면, 댓글을 삭제한다.")
         @Test
         void givenCommentId_whenCallingDeleteCommentApi_thenDeletesComment() throws Exception {
@@ -144,16 +121,12 @@ class ArticleCommentManagementServiceTest {
                     .expect(requestTo(projectProperties.board().url() + "/api/articleComments/" + articleCommentId))
                     .andExpect(method(HttpMethod.DELETE))
                     .andRespond(withSuccess());
-
             // When
             sut.deleteArticleComment(articleCommentId);
-
             // Then
             server.verify();
         }
     }
-
-
     private ArticleCommentDto createArticleCommentDto(String content) {
         return ArticleCommentDto.of(
                 1L,
@@ -167,16 +140,13 @@ class ArticleCommentManagementServiceTest {
                 "Uno"
         );
     }
-
     private UserAccountDto createUserAccountDto() {
         return UserAccountDto.of(
                 "unoTest",
-                "pw",
                 Set.of(RoleType.ADMIN),
                 "uno-test@email.com",
                 "uno-test",
                 "test memo"
         );
     }
-
 }

--- a/src/test/java/com/fastcampus/projectboardadmin/service/ArticleManagementServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/service/ArticleManagementServiceTest.java
@@ -38,12 +38,10 @@ class ArticleManagementServiceTest {
         public RealApiTest(ArticleManagementService sut) {
             this.sut = sut;
         }
-
         @DisplayName("게시글 API를 호출하면, 게시글을 가져온다.")
         @Test
         void givenNothing_whenCallingArticleApi_thenReturnsArticleList() {
             // Given
-
             // When
             List<ArticleDto> result = sut.getArticles();
             // Then
@@ -147,7 +145,6 @@ class ArticleManagementServiceTest {
         private UserAccountDto createUserAccountDto() {
             return UserAccountDto.of(
                     "unoTest",
-                    "pw",
                     Set.of(RoleType.ADMIN),
                     "uno-test@email.com",
                     "uno-test",


### PR DESCRIPTION
이 pr은 댓글 관리 페이지 기능을 구현하기 위한 비즈니스 로직과 컨트롤러의 테스트를 추가한다.
구현이 없으므로 테스트가 실패하는 상태.

This closes #44